### PR TITLE
Add link status updating with AJAX

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ group :development, :test do
   gem 'pry'
   gem 'launchy'
   gem 'capybara'
+  gem 'capybara-webkit'
+  gem 'database_cleaner'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.7.1)
+      capybara (>= 2.3.0, < 2.6.0)
+      json
     coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -62,6 +65,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
@@ -190,7 +194,9 @@ DEPENDENCIES
   binding_of_caller
   byebug
   capybara
+  capybara-webkit
   coffee-rails (~> 4.1.0)
+  database_cleaner
   jbuilder (~> 2.0)
   jquery-rails
   launchy

--- a/app/assets/javascripts/links/update.js.erb
+++ b/app/assets/javascripts/links/update.js.erb
@@ -1,0 +1,27 @@
+$('.status').on('click', function() {
+  var $linkId = $(this).parent().parent().data('id');
+  var $linkStatus = $(this).data('read');
+
+  $.ajax({
+    url: '/links/' + $linkId,
+    type: "PATCH",
+    data: { link: { read: $linkStatus } },
+    success: function(data) {
+      var id     = data.id;
+      var $link = $('.link[data-id=' + id + ']')
+      var $title = $link.find('.title');
+      var $status = $link.find('.status');
+      var title  = data.title;
+      var status = '';
+      if (data.read) {
+        status = 'Mark as Unread';
+      } else {
+        status = 'Mark as Read';
+      }
+
+      $title.toggleClass('read');
+      $status.innerHTML = status;
+      $status.data('read', data.read);
+    }
+  });
+});

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -1,0 +1,8 @@
+.read {
+  color: gray;
+  text-decoration: line-through;
+}
+
+.unread {
+  color: black;
+}

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -18,9 +18,21 @@ class LinksController < ApplicationController
     redirect_to links_path
   end
 
+  def update
+    @link = current_user.links.find(params[:id])
+
+    if @link && @link.update(title: params[:title], read: !params[:read])
+      flash[:success] = "#{@link.title} updated!"
+      render json: @link
+    else
+      flash[:warning] = "Unable to update link."
+      render json: { success: false }
+    end
+  end
+
 private
 
   def link_params
-    params.require(:link).permit(:url, :title)
+    params.require(:link).permit(:url, :title, :read)
   end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -4,6 +4,12 @@ class Link < ActiveRecord::Base
   validate :url_must_be_valid
   belongs_to :user
 
+  def status
+    read ? "read" : "unread"
+  end
+
+private
+
   def url_must_be_valid
     uri = URI.parse(url)
     errors.add(:url, "must be valid") unless uri.kind_of?(URI::HTTP)

--- a/app/views/links/_link.html.erb
+++ b/app/views/links/_link.html.erb
@@ -1,0 +1,7 @@
+<div class="link" data-id="<%= link.id %>">
+  <div><%= link_to link.title, link.url, class: ["title", link.status] %></div>
+  <div>
+    <%= link_to (link.read ? "Mark as Unread" : "Mark as Read"), "#",
+      class: "status", "data-read": link.read %>
+  </div>
+</div>

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -8,13 +8,12 @@
 <% end %>
 
 <h2>My Links</h2>
-<% if @links %>
-  <% @links.each do |link| %>
-    <div>
-      <p><%= link_to link.title, link.url %></p>
-      <p><%= link.read ? "read" : "unread" %></p>
-    </div>
+<div id="links">
+  <% if @links %>
+    <%= render @links %>
+  <% else %>
+    Submit a link above.
   <% end %>
-<% else %>
-  Submit a link above.
-<% end %>
+</div>
+
+<%= javascript_include_tag "links/update" %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,3 +9,4 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( links/update.js )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   get "/signup" => "users#new"
 
   resources :users, only: [:new, :create]
-  resources :links, only: [:index, :create]
+  resources :links, only: [:index, :create, :update]
   resources :sessions, only: [:new, :create, :destroy]
 
   # Example of regular route:

--- a/spec/features/user_can_submit_and_view_links_spec.rb
+++ b/spec/features/user_can_submit_and_view_links_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Authenitcated user can submit and view links", type: :feature do
     fill_in "Title", with: "Bad Motivator Blog"
     click_button "Submit"
 
-    expect(page).to have_content("unread")
+    expect(page).to have_content("Mark as Read")
   end
 
   scenario "Submitting an invalid link results in an error message" do

--- a/spec/features/user_can_update_link_status_spec.rb
+++ b/spec/features/user_can_update_link_status_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.feature "User can update link status", type: :feature do
+  before do
+    User.create(
+      email_address: "samson@example.com",
+      password:      "password"
+    )
+
+    visit login_path
+    fill_in "Email address", with: "samson@example.com"
+    fill_in "Password", with: "password"
+    click_button "Submit"
+
+    visit links_path
+    fill_in "Url", with: "http://badmotivator.io/"
+    fill_in "Title", with: "Bad Motivator Blog"
+    click_button "Submit"
+  end
+
+  xscenario "User can update new link status from unread to read", js: true do
+    visit links_path
+
+    click_link_or_button "Mark as Read"
+
+    expect(page).to have_link("Mark as Unread")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rails'
+Capybara.javascript_driver = :webkit
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -34,8 +35,27 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.


### PR DESCRIPTION
As an authenticated user who has added links to my Spinboard, when I view the link index:
- Next to each unread link I should see an option to "Mark as Read".
- Clicking this should update the link appropriately and take me immediately back to the my links.
- Next to each read link I should see an option to "Mark as Unread".
- Clicking this should update the link appropriately and take me immediately back to the my links.
- Read links should be stylistically differentiated from unread links. You could gray them out or use a strike through.
