### PR TITLE
Add ability to edit links

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -18,15 +18,25 @@ class LinksController < ApplicationController
     redirect_to links_path
   end
 
+  def edit
+    @link = current_user.links.find(params[:id])
+  end
+
   def update
     @link = current_user.links.find(params[:id])
 
-    if @link && @link.update(title: params[:title], read: !params[:read])
+    if @link && @link.update(link_params)
       flash[:success] = "#{@link.title} updated!"
-      render json: @link
+      respond_to do |format|
+        format.html { redirect_to links_path }
+        format.json { render json: @link }
+      end
     else
       flash[:warning] = "Unable to update link."
-      render json: { success: false }
+      respond_to do |format|
+        format.html { redirect_to links_path }
+        format.json { render json: { success: false } }
+      end
     end
   end
 

--- a/app/views/links/_link.html.erb
+++ b/app/views/links/_link.html.erb
@@ -4,4 +4,7 @@
     <%= link_to (link.read ? "Mark as Unread" : "Mark as Read"), "#",
       class: "status", "data-read": link.read %>
   </div>
+  <div>
+    <%= link_to "Edit", edit_link_path(link) %>
+  </div>
 </div>

--- a/app/views/links/edit.html.erb
+++ b/app/views/links/edit.html.erb
@@ -1,0 +1,8 @@
+<h2>Edit Link</h2>
+<%= form_for @link, method: :patch do |f| %>
+  <%= f.label :url %>
+  <%= f.text_field :url %>
+  <%= f.label :title %>
+  <%= f.text_field :title %>
+  <%= f.submit "Submit" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,55 +10,6 @@ Rails.application.routes.draw do
   get "/signup" => "users#new"
 
   resources :users, only: [:new, :create]
-  resources :links, only: [:index, :create, :update]
+  resources :links, only: [:index, :create, :update, :edit]
   resources :sessions, only: [:new, :create, :destroy]
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
 end

--- a/spec/features/user_can_edit_links_spec.rb
+++ b/spec/features/user_can_edit_links_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.feature "User can edit links", type: :feature do
+  before do
+    User.create(
+      email_address: "samson@example.com",
+      password:      "password"
+    )
+
+    visit login_path
+    fill_in "Email address", with: "samson@example.com"
+    fill_in "Password", with: "password"
+    click_button "Submit"
+
+    visit links_path
+    fill_in "Url", with: "http://badmotivator.io/"
+    fill_in "Title", with: "Bad Motivator Blog"
+    click_button "Submit"
+  end
+
+  scenario "User can click edit button and edit link" do
+    visit links_path
+
+    click_link_or_button "Edit"
+    fill_in "Url", with: "http://newlink.com/"
+    fill_in "Title", with: "New Link"
+    click_button "Submit"
+
+    expect(page).to have_link("New Link")
+  end
+
+  scenario "User cannot change url to an invalid url" do
+    visit links_path
+
+    click_link_or_button "Edit"
+    fill_in "Url", with: "bad#url"
+    fill_in "Title", with: "New Link"
+    click_button "Submit"
+
+    expect(page).to have_content("Unable to update link.")
+    expect(page).to have_link("Bad Motivator Blog")
+  end
+end


### PR DESCRIPTION
As an authenticated user who has added links to my Spinboard, when I view the link index:
- Each link has an "Edit" button that either takes me to a page to edit the link or allows me to edit the link in place.
- I can edit the title or the URL of the link.
- I cannot change the URL to an invalid URL.
