### PR TITLE
Add search and filter options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'puma'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'will_paginate'
+gem 'filterrific'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.6.0)
+    filterrific (2.0.5)
+      rails (>= 3.1.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -181,6 +183,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -197,6 +200,7 @@ DEPENDENCIES
   capybara-webkit
   coffee-rails (~> 4.1.0)
   database_cleaner
+  filterrific
   jbuilder (~> 2.0)
   jquery-rails
   launchy
@@ -210,6 +214,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  will_paginate
 
 BUNDLED WITH
    1.10.6

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,4 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require filterrific/filterrific-jquery
 //= require_tree .

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,8 +1,73 @@
 require "uri"
 
 class Link < ActiveRecord::Base
+  filterrific(
+    default_filter_params: { sorted_by: 'created_at_desc' },
+    available_filters: [
+      :sorted_by,
+      :read_status,
+      :search_query
+    ]
+  )
+
   validate :url_must_be_valid
   belongs_to :user
+
+  scope :sorted_by, lambda { |sort_option|
+    # extract the sort direction from the param value.
+    direction = (sort_option =~ /desc$/) ? 'desc' : 'asc'
+    case sort_option.to_s
+    when /^created_at_/
+      # Simple sort on the created_at column.
+      # Make sure to include the table name to avoid ambiguous column names.
+      # Joining on other tables is quite common in Filterrific, and almost
+      # every ActiveRecord table has a 'created_at' column.
+      order("links.created_at #{ direction }")
+    when /^title_/
+      # Simple sort on the title column
+      order("LOWER(links.title) #{ direction }")
+    else
+      raise(ArgumentError, "Invalid sort option: #{ sort_option.inspect }")
+    end
+  }
+
+  scope :read_status, lambda { |read_status|
+    where("read = ?", read_status)
+  }
+
+  scope :search_query, lambda { |query|
+    return nil  if query.blank?
+
+    # condition query, parse into individual keywords
+    terms = query.downcase.split(/\s+/)
+
+    # replace "*" with "%" for wildcard searches,
+    # append '%', remove duplicate '%'s
+    terms = terms.map { |e|
+      (e.gsub('*', '%') + '%').gsub(/%+/, '%')
+    }
+    # configure number of OR conditions for provision
+    # of interpolation arguments. Adjust this if you
+    # change the number of OR conditions.
+    num_or_conds = 1
+    where(
+      terms.map { |term|
+        "(LOWER(links.title) ILIKE ?)"
+      }.join(' AND '),
+      *terms.map { |e| [e] * num_or_conds }.flatten
+    )
+  }
+
+  def self.options_for_read_status
+    [true, false]
+  end
+
+  def self.options_for_sorted_by
+    [
+      ["Title (a-z)", "title_asc"],
+      ["Title (z-a)", "title_desc"]
+    ]
+  end
 
   def status
     read ? "read" : "unread"

--- a/app/views/links/_list.html.erb
+++ b/app/views/links/_list.html.erb
@@ -1,0 +1,22 @@
+<div id="filterrific_results">
+  <div>
+    <%= page_entries_info links %>
+  </div>
+
+  <table>
+    <tr>
+      <th>URL</th>
+      <th>Title</th>
+      <th>&nbsp;</th>
+    </tr>
+    <% links.each do |link| %>
+      <tr>
+        <td><%= link.url %></td>
+        <td><%= link.title %></td>
+        <td><%= link.read %></td>
+      </tr>
+    <% end %>
+  </table>
+</div>
+
+<%= will_paginate links %>

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -8,28 +8,40 @@
 <% end %>
 
 <h2>Search/Filter</h2>
-<div>
-  Search: <input type="text" name="search" id="search">
-  <button id="btn-search">Search</button><br>
+<%= form_for_filterrific @filterrific do |f| %>
+  <div>
+    Search
+    <%# give the search field the 'filterrific-periodically-observed' class for live updates %>
+    <%= f.text_field(
+      :search_query,
+      class: 'filterrific-periodically-observed'
+    ) %>
+  </div>
+  <div>
+    Read?
+    <%= f.select(
+      :read_status,
+      @filterrific.select_options[:read_status],
+      { include_blank: '- Any -' }
+    ) %>
+  </div>
+  <div>
+    Sorted by
+    <%= f.select(:sorted_by, @filterrific.select_options[:sorted_by]) %>
+  </div>
+  <div>
+    <%= link_to(
+      'Reset filters',
+      reset_filterrific_url,
+    ) %>
+  </div>
+  <%# add an automated spinner to your form when the list is refreshed %>
+  <%= render_filterrific_spinner %>
+<% end %>
 
-  Status:
-  <select name="status-select" id="status-select">
-    <option value="">Select status</option>
-    <option value="true">Read</option>
-    <option value="false">Unread</option>
-  </select>
+<%= render(
+  partial: "links/list",
+  locals: { links: @links }
+) %>
 
-  <button id="btn-atoz">A to Z</button>
-  <button id="btn-ztoa">Z to A</button>
-</div>
-
-<h2>My Links</h2>
-<div id="links">
-  <% if @links %>
-    <%= render @links %>
-  <% else %>
-    Submit a link above.
-  <% end %>
-</div>
-
-<%= javascript_include_tag "links/update" %>
+<%# javascript_include_tag "links/update" %>

--- a/app/views/links/index.js.erb
+++ b/app/views/links/index.js.erb
@@ -1,0 +1,4 @@
+<% js = escape_javascript(
+  render(partial: 'links/list', locals: { links: @links })
+) %>
+$("#filterrific_results").html("<%= js %>");


### PR DESCRIPTION
As an authenticated user, I can do the following in the link index without reloading the page:
- Filter the list of links by a search term
- Filter the list by status (e.g. "read" and "unread")
- Sort the list alphabetically
