### PR TITLE
Iteration 4: Reenable edit link

### DIFF
--- a/app/views/links/_list.html.erb
+++ b/app/views/links/_list.html.erb
@@ -13,7 +13,7 @@
       <tr>
         <td><%= link_to link.title, link.url, class: link.status %></td>
         <td><%= read_status_url(link) %></td>
-        <td>Edit</td>
+        <td><%= link_to "Edit", edit_link_path(link), class: "btn btn-default" %></td>
       </tr>
     <% end %>
   </table>


### PR DESCRIPTION
As an authenticated user who has added links to my Spinboard, when I view the link index:
- Each link has an "Edit" button that either takes me to a page to edit the link or allows me to edit the link in place.
- I can edit the title or the URL of the link.
- I cannot change the URL to an invalid URL.
